### PR TITLE
hash計算をgoのbuilt-in libraryを使って行う

### DIFF
--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	crand "crypto/rand"
+	"crypto/sha512"
 	"fmt"
 	"github.com/felixge/fgprof"
 	"html/template"
@@ -10,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -121,14 +121,7 @@ func escapeshellarg(arg string) string {
 }
 
 func digest(src string) string {
-	// opensslのバージョンによっては (stdin)= というのがつくので取る
-	out, err := exec.Command("/bin/bash", "-c", `printf "%s" `+escapeshellarg(src)+` | openssl dgst -sha512 | sed 's/^.*= //'`).Output()
-	if err != nil {
-		log.Print(err)
-		return ""
-	}
-
-	return strings.TrimSuffix(string(out), "\n")
+	return fmt.Sprintf("%x", sha512.Sum512([]byte(src)))
 }
 
 func calculateSalt(accountName string) string {


### PR DESCRIPTION
refs #1 

https://github.com/pinkumohikan/isucon-practice-20240824-private-isu/issues/1#issuecomment-2352255617 に対する改善
パスワードのhash計算をosコマンド呼び出しにより計算していてオーバーヘッドが大きそうなので、goのbuilt-in libraryで計算を行うように改修